### PR TITLE
Make description default value equal empty string

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -14,7 +14,7 @@ exports.options = {
   canHaveName: false,
   onTagged: function (doclet, tag) {
     doclet.authentication = tag.value
-    doclet.description = `${doclet.description}
+    doclet.description = `${doclet.description || ''}
                           <h5>Authentication</h5>
                           <p>${doclet.authentication || 'A authentication is needed to access this endpoint'}</p>`
   }

--- a/lib/bodyparam.js
+++ b/lib/bodyparam.js
@@ -33,7 +33,7 @@ exports.newDocletHandler = function (e) {
   if (parameters) {
     const table = tableBuilder.build('Body Parameters', parameters)
 
-    e.doclet.description = `${e.doclet.description}
+    e.doclet.description = `${e.doclet.description || ''}
                             ${table}`
   }
 }

--- a/lib/headerparam.js
+++ b/lib/headerparam.js
@@ -33,7 +33,7 @@ exports.newDocletHandler = function (e) {
   if (parameters) {
     const table = tableBuilder.build('Header Parameters', parameters)
 
-    e.doclet.description = `${e.doclet.description}
+    e.doclet.description = `${e.doclet.description || ''}
                             ${table}`
   }
 }

--- a/lib/queryparam.js
+++ b/lib/queryparam.js
@@ -33,7 +33,7 @@ exports.newDocletHandler = function (e) {
   if (parameters) {
     const table = tableBuilder.build('Query Parameters', parameters)
 
-    e.doclet.description = `${e.doclet.description}
+    e.doclet.description = `${e.doclet.description || ''}
                             ${table}`
   }
 }

--- a/lib/responsecode.js
+++ b/lib/responsecode.js
@@ -30,7 +30,7 @@ exports.newDocletHandler = function (e) {
   if (parameters) {
     const table = tableBuilder.build('Response Code', parameters, { name: false })
 
-    e.doclet.description = `${e.doclet.description}
+    e.doclet.description = `${e.doclet.description || ''}
                             ${table}`
   }
 }

--- a/lib/responseparam.js
+++ b/lib/responseparam.js
@@ -33,7 +33,7 @@ exports.newDocletHandler = function (e) {
   if (parameters) {
     const table = tableBuilder.build('Response', parameters)
 
-    e.doclet.description = `${e.doclet.description}
+    e.doclet.description = `${e.doclet.description || ''}
                             ${table}`
   }
 }

--- a/lib/route.js
+++ b/lib/route.js
@@ -31,6 +31,6 @@ exports.newDocletHandler = function (e) {
                             <td class="name last">${route.name}</td>
                             </tr>
                             </table>
-                            ${e.doclet.description}`
+                            ${e.doclet.description || ''}`
   }
 }

--- a/lib/routeparam.js
+++ b/lib/routeparam.js
@@ -31,7 +31,7 @@ exports.newDocletHandler = function (e) {
   if (parameters) {
     const table = tableBuilder.build('Route Parameters', parameters)
 
-    e.doclet.description = `${e.doclet.description}
+    e.doclet.description = `${e.doclet.description || ''}
                             ${table}`
   }
 }


### PR DESCRIPTION
To prevent `undefined` being rendered in the final document.

Fixes #3 