### PR TITLE
Adding @chain tags (for middlewares sequence describing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ volumes/
 *.tgz
 scripts/node_modules
 /out
+.idea
+.DS_Store
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -338,6 +338,44 @@ server.get({
 }, (req, res, next) => {...}
 ```
 
+## @chain
+
+The `@chain` allows you to document the sequence of handlers which will handle the request before current endpoint or middleware,  for e.g it may be the express.js middlewares. 
+
+With this tag you may provide @link or human-friendly name of chain element. It is important to keep order of @chain declarations same as real request handling order.
+* `@chain {@link module:<full-path-to-module-member>} || @chain <human-friendly-endpoint-name>`
+
+```js
+/**
+ * Handlers chain - example middleware
+ *
+ * @name SomeMiddleware
+ * @path {POST} /v1/chain
+ * @version v1
+ * @since v1
+ */
+
+app.get('/v1/chain', function (request, response, next) {
+  ...
+  next()
+})
+
+/**
+ * Handlers chain - endpoint after the middleware
+ *
+ * @name SomeEndpoint
+ * @path {POST} /v1/chain
+ * @version v1
+ * @since v1
+ * @code 200
+ * @chain {@module:MyRoutes.SomeMiddleware}
+ * @chain {@module:MyRoutes.SomeEndpoint} 
+ */
+app.get('/v1/chain', function (request, response) {
+  ...
+})
+```
+
 The above would add a table under the route description that lists that the route answer with a json document containing the `name` and `link` key.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -354,7 +354,6 @@ With this tag you may provide @link or human-friendly name of chain element. It 
  * @version v1
  * @since v1
  */
-
 app.get('/v1/chain', function (request, response, next) {
   ...
   next()
@@ -368,8 +367,8 @@ app.get('/v1/chain', function (request, response, next) {
  * @version v1
  * @since v1
  * @code 200
- * @chain {@module:MyRoutes.SomeMiddleware}
- * @chain {@module:MyRoutes.SomeEndpoint} 
+ * @chain {@link module:MyRoutes.SomeMiddleware}
+ * @chain This handler
  */
 app.get('/v1/chain', function (request, response) {
   ...

--- a/examples/index.js
+++ b/examples/index.js
@@ -111,6 +111,35 @@ app.get('/v1/files', function (request, response) {
   request.send({ data: { msg: 'Your Files' } })
 })
 
+
+/**
+ * Handlers chain - example middleware
+ *
+ * @name Handlers Chain - Middleware
+ * @path {POST} /v1/chain
+ * @version v1
+ * @since v1
+ */
+
+app.get('/v1/chain', function (request, response, next) {
+  next()
+})
+
+/**
+ * Handlers chain - endpoint after the middleware
+ *
+ * @name Handlers Chain - Endpoint
+ * @path {POST} /v1/chain
+ * @version v1
+ * @since v1
+ * @code 200
+ * @chain Handlers Chain - Middleware
+ * @chain Handlers Chain - Endpoint
+ */
+app.get('/v1/chain', function (request, response) {
+  request.send(200)
+})
+
 app.listen(3000, function () {
   console.log('Example app is listening on port 3000, have fun!')
 })

--- a/examples/index.js
+++ b/examples/index.js
@@ -114,27 +114,32 @@ app.get('/v1/files', function (request, response) {
 
 /**
  * Handlers chain - example middleware
- *
- * @name Handlers Chain - Middleware
+ * @name SomeMiddleware
  * @path {POST} /v1/chain
  * @version v1
  * @since v1
  */
-
 app.get('/v1/chain', function (request, response, next) {
   next()
 })
 
 /**
+ *
+ */
+function all () {
+
+}
+
+/**
  * Handlers chain - endpoint after the middleware
  *
- * @name Handlers Chain - Endpoint
+ * @name SomeEndpoint
  * @path {POST} /v1/chain
  * @version v1
  * @since v1
  * @code 200
- * @chain Handlers Chain - Middleware
- * @chain Handlers Chain - Endpoint
+ * @chain {@link module:MyRoutes.SomeMiddleware}
+ * @chain This handler
  */
 app.get('/v1/chain', function (request, response) {
   request.send(200)

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const routeParameterTag = require('./lib/routeparam')
 const responseParameterTag = require('./lib/responseparam')
 const responseCodeTag = require('./lib/responsecode')
 const serviceTag = require('./lib/serviceparam')
+const chainTag = require('./lib/chain')
 
 exports.defineTags = function (dictionary) {
   dictionary.defineTag(serviceTag.name, serviceTag.options)
@@ -25,6 +26,7 @@ exports.defineTags = function (dictionary) {
   dictionary.defineTag(routeParameterTag.name, routeParameterTag.options)
   dictionary.defineTag(responseParameterTag.name, responseParameterTag.options)
   dictionary.defineTag(responseCodeTag.name, responseCodeTag.options)
+  dictionary.defineTag(chainTag.name, chainTag.options)
 }
 
 exports.handlers = {
@@ -38,5 +40,6 @@ exports.handlers = {
     routeTag.newDocletHandler(e)
     responseParameterTag.newDocletHandler(e)
     responseCodeTag.newDocletHandler(e)
+    chainTag.newDocletHandler(e)
   }
 }

--- a/lib/chain.js
+++ b/lib/chain.js
@@ -1,0 +1,59 @@
+/**
+ * This module defines a custom jsDoc tag.
+ * It allows you to document middlewares / endpoints chain for route
+ * @module lib/chain
+ */
+
+'use strict'
+
+exports.name = 'chain'
+exports.options = {
+    mustHaveValue: true,
+    mustNotHaveDescription: false,
+    canHaveType: false,
+    canHaveName: true,
+    onTagged: function (doclet, tag) {
+        if (!doclet.chain) {
+            doclet.chain = []
+        }
+
+        doclet.chain.push({
+            'name': tag.text,
+        })
+    }
+}
+
+
+const links = {}
+
+exports.newDocletHandler = function (e) {
+
+
+    links[e.doclet.name] =  {
+        longname: e.doclet.longname,
+        link: e.doclet.memberof ? `${e.doclet.memberof.replace(':', '-')}.html#${e.doclet.name}`.replace(/ /g, '') : ''
+    }
+
+
+    const chain = e.doclet.chain
+
+
+        if (chain && chain.length) {
+
+
+                e.doclet.description = `<h5>Handlers Chain:</h5>
+                            <table class="params">
+                            <thead><tr><th>Name</th><th class="last">Link</th></tr></thead>
+                            ${chain.reduce((html, handler) => {
+                                
+                                html += `<tr>
+                            <td class="type">${handler.name}</td>
+                            ${links[handler.name] ? `<td class="name last"><a href=${links[handler.name].link}>${links[handler.name].longname}</a></td>` : '' }
+                            </tr>`
+                                
+                                return html            
+                }, '')}
+                            </table>
+                            ${e.doclet.description || ''}`
+            }
+}

--- a/lib/chain.js
+++ b/lib/chain.js
@@ -35,7 +35,7 @@ exports.newDocletHandler = function (e) {
 
                 e.doclet.description = `<h5>Handlers Chain:</h5>
                             <table class="params">
-                            <thead><tr class="last"><th>Name</th></tr></thead>
+                            <thead><tr class="last"><th>Order</th></tr></thead>
                             ${chain.reduce((html, handler) => {
                                 
                                 html += `<tr><td class="type">${handler.name}</td></tr>`

--- a/lib/chain.js
+++ b/lib/chain.js
@@ -23,16 +23,8 @@ exports.options = {
     }
 }
 
-
-const links = {}
-
 exports.newDocletHandler = function (e) {
 
-
-    links[e.doclet.name] =  {
-        longname: e.doclet.longname,
-        link: e.doclet.memberof ? `${e.doclet.memberof.replace(':', '-')}.html#${e.doclet.name}`.replace(/ /g, '') : ''
-    }
 
 
     const chain = e.doclet.chain
@@ -43,13 +35,10 @@ exports.newDocletHandler = function (e) {
 
                 e.doclet.description = `<h5>Handlers Chain:</h5>
                             <table class="params">
-                            <thead><tr><th>Name</th><th class="last">Link</th></tr></thead>
+                            <thead><tr class="last"><th>Name</th></tr></thead>
                             ${chain.reduce((html, handler) => {
                                 
-                                html += `<tr>
-                            <td class="type">${handler.name}</td>
-                            ${links[handler.name] ? `<td class="name last"><a href=${links[handler.name].link}>${links[handler.name].longname}</a></td>` : '' }
-                            </tr>`
+                                html += `<tr><td class="type">${handler.name}</td></tr>`
                                 
                                 return html            
                 }, '')}


### PR DESCRIPTION
Adding multiple '@chain' tags to describe order of handling request, for e.g the express.js middlewares order.

See README.md